### PR TITLE
#7 set token expiry period to 1 day

### DIFF
--- a/Services/AccountService.cs
+++ b/Services/AccountService.cs
@@ -158,7 +158,7 @@ namespace WebApi.Services
 
             // create reset token that expires after 1 day
             account.ResetToken = randomTokenString();
-            account.ResetTokenExpires = DateTime.UtcNow.AddDays(24);
+            account.ResetTokenExpires = DateTime.UtcNow.AddDays(1);
 
             _context.Accounts.Update(account);
             _context.SaveChanges();


### PR DESCRIPTION
Change token expiry period for ForgotPassword to 1 day from 24 days.