### PR TITLE
Added Swagger Authentication. Fixed Refresh Token Security Issue

### DIFF
--- a/Services/AccountService.cs
+++ b/Services/AccountService.cs
@@ -60,7 +60,17 @@ namespace WebApi.Services
 
             // authentication successful so generate jwt and refresh tokens
             var jwtToken = generateJwtToken(account);
-            var refreshToken = generateRefreshToken(ipAddress);
+            RefreshToken refreshToken;
+            // check if there is an active refresh token already and use that instead of generating a new one
+            RefreshToken activeRefreshToken = account.RefreshTokens.SingleOrDefault(r => r.IsActive && r.Expires >= DateTime.UtcNow);
+            if (activeRefreshToken != null && activeRefreshToken.IsActive)
+            {
+                refreshToken = activeRefreshToken;
+            }
+            else
+            {
+                refreshToken = generateRefreshToken(ipAddress);
+            }
 
             // save refresh token
             account.RefreshTokens.Add(refreshToken);

--- a/Startup.cs
+++ b/Startup.cs
@@ -4,7 +4,9 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using System;
+using System.Collections.Generic;
 using WebApi.Helpers;
 using WebApi.Middleware;
 using WebApi.Services;
@@ -27,7 +29,38 @@ namespace WebApi
             services.AddCors();
             services.AddControllers().AddJsonOptions(x => x.JsonSerializerOptions.IgnoreNullValues = true);
             services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
-            services.AddSwaggerGen();
+            services.AddSwaggerGen(c =>
+            {
+                c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+                {
+                    Description = @"JWT Authorization header using the Bearer scheme. \r\n\r\n 
+                      Enter 'Bearer' [space] and then your token in the text input below.
+                      \r\n\r\nExample: 'Bearer 12345abcdef'",
+                    Name = "Authorization",
+                    In = ParameterLocation.Header,
+                    Type = SecuritySchemeType.ApiKey,
+                    Scheme = "Bearer"
+                });
+
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement()
+                  {
+                    {
+                      new OpenApiSecurityScheme
+                      {
+                        Reference = new OpenApiReference
+                          {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                          },
+                          Scheme = "oauth2",
+                          Name = "Bearer",
+                          In = ParameterLocation.Header,
+
+                        },
+                        new List<string>()
+                      }
+                    });
+            });
 
             // configure strongly typed settings object
             services.Configure<AppSettings>(Configuration.GetSection("AppSettings"));


### PR DESCRIPTION
Added Authentication for Swagger to set the Bearer token for other Authorized API calls to test against. 

Changed Authenticate function to only create a Refresh Token when no active Refresh Token is found so no Active Refresh Tokens are kept where a potential leak on the user could expose risk to the API