### PR TITLE
Missing header "From", EmailService FIX: Issue #6

### DIFF
--- a/Services/EmailService.cs
+++ b/Services/EmailService.cs
@@ -29,6 +29,7 @@ namespace WebApi.Services
             email.To.Add(MailboxAddress.Parse(to));
             email.Subject = subject;
             email.Body = new TextPart(TextFormat.Html) { Text = html };
+            email.From.Add(new MailboxAddress("Displayed name", from ?? _appSettings.EmailFrom));
 
             // send email
             using var smtp = new SmtpClient();


### PR DESCRIPTION
This PR addresses issue #6.
Gmail requires "from" header to receive email. 

Full error message from inbox I tried to send emails:
"Messages missing a valid address in
From: 550 5.7.1 header, or **having no From: header, are not accepted.**"

